### PR TITLE
inherit from public std::enable_shared_from_this

### DIFF
--- a/lang/c++/api/Node.hh
+++ b/lang/c++/api/Node.hh
@@ -86,7 +86,7 @@ std::ostream& operator << (std::ostream& os, const Name& n) {
 /// different node types.
 ///
 
-class AVRO_DECL Node : protected std::enable_shared_from_this<Node>,
+class AVRO_DECL Node : public std::enable_shared_from_this<Node>,
                        private boost::noncopyable
 {
   public:


### PR DESCRIPTION
to address compiler error when clang-12, libstdc++-11.2.1 are used.