### PR TITLE
c++: NodePrimitive::resolve allow futherResolution for STRING and BYTES

### DIFF
--- a/lang/c++/impl/NodeImpl.cc
+++ b/lang/c++/impl/NodeImpl.cc
@@ -132,11 +132,19 @@ NodePrimitive::resolve(const Node &reader) const {
 
         case AVRO_BYTES:
 
-            return reader.type() == AVRO_STRING ? RESOLVE_MATCH : RESOLVE_NO_MATCH;
+            if (reader.type() == AVRO_STRING) {
+                return RESOLVE_MATCH;
+            }
+
+            break;
 
         case AVRO_STRING:
 
-            return reader.type() == AVRO_BYTES ? RESOLVE_MATCH : RESOLVE_NO_MATCH;
+            if (reader.type() == AVRO_BYTES) {
+                return RESOLVE_MATCH;
+            }
+
+            break;
 
         default: break;
     }

--- a/lang/c++/test/unittest.cc
+++ b/lang/c++/test/unittest.cc
@@ -956,6 +956,11 @@ struct TestResolution {
             two.addType(IntSchema());
             two.addType(DoubleSchema());
             unionTwo_.setSchema(two);
+
+            UnionSchema three;
+            three.addType(NullSchema());
+            three.addType(StringSchema());
+            unionThree_.setSchema(three);
         }
     }
 
@@ -1013,6 +1018,7 @@ struct TestResolution {
         BOOST_CHECK_EQUAL(resolve(unionOne_, double_), RESOLVE_PROMOTABLE_TO_DOUBLE);
         BOOST_CHECK_EQUAL(resolve(unionTwo_, float_), RESOLVE_PROMOTABLE_TO_FLOAT);
         BOOST_CHECK_EQUAL(resolve(unionOne_, unionTwo_), RESOLVE_MATCH);
+        BOOST_CHECK_EQUAL(resolve(string_, unionThree_), RESOLVE_MATCH);
 
 
         BOOST_CHECK_EQUAL(resolve(string_, bytes_), RESOLVE_MATCH);
@@ -1039,6 +1045,7 @@ private:
 
     ValidSchema unionOne_;
     ValidSchema unionTwo_;
+    ValidSchema unionThree_;
 };
 
 void testNestedArraySchema() {


### PR DESCRIPTION
The early exit for no match prevents a union containing a string from resolving a string.

Signed-off-by: Ben Pope <ben@redpanda.com>
