### PR TITLE
Jcipar/core 5087 changes to support iceberg

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required (VERSION 3.1)
 set (CMAKE_LEGACY_CYGWIN_WIN32 0)
 
 if (NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD 17)
 endif()
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -64,7 +64,7 @@ if (WIN32 AND NOT CYGWIN AND NOT MSYS)
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Werror")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Werror -Wno-dangling-reference -Wno-maybe-uninitialized")
 if (AVRO_ADD_PROTECTOR_FLAGS)
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fstack-protector-all -D_GLIBCXX_DEBUG")
     # Unset _GLIBCXX_DEBUG for avrogencpp.cc because using Boost Program Options

--- a/lang/c++/impl/Compiler.cc
+++ b/lang/c++/impl/Compiler.cc
@@ -362,6 +362,8 @@ static LogicalType makeLogicalType(const Entity &e, const Object &m) {
         t = LogicalType::DURATION;
     else if (typeField == "uuid")
         t = LogicalType::UUID;
+    else if (typeField == "map")
+        t = LogicalType::MAP;
     return LogicalType(t);
 }
 

--- a/lang/c++/impl/Compiler.cc
+++ b/lang/c++/impl/Compiler.cc
@@ -423,8 +423,12 @@ static NodePtr makeFixedNode(const Entity &e,
 static NodePtr makeArrayNode(const Entity &e, const Object &m,
                              SymbolTable &st, const string &ns) {
     auto it = findField(e, m, "items");
-    NodePtr node = NodePtr(std::make_shared<NodeArray>(
-        asSingleAttribute(makeNode(it->second, st, ns))));
+    std::shared_ptr<NodeArray> nodePointer = std::make_shared<NodeArray>(
+        asSingleAttribute(makeNode(it->second, st, ns)));
+    NodePtr node = NodePtr(nodePointer);
+    if (containsField(m, "element-id")) {
+        nodePointer->elementId_ = getStringField(e, m, "element-id");
+    }
     if (containsField(m, "doc")) {
         node->setDoc(getDocField(e, m));
     }

--- a/lang/c++/impl/DataFile.cc
+++ b/lang/c++/impl/DataFile.cc
@@ -20,6 +20,8 @@
 #include "Compiler.hh"
 #include "Exception.hh"
 
+#include <map>
+#include <optional>
 #include <sstream>
 
 #include <boost/crc.hpp> // for boost::crc_32_type
@@ -64,7 +66,7 @@ boost::iostreams::zlib_params get_zlib_params() {
 } // namespace
 
 DataFileWriterBase::DataFileWriterBase(const char *filename, const ValidSchema &schema, size_t syncInterval,
-                                       Codec codec) : filename_(filename),
+                                       Codec codec, const std::map<std::string, std::string> &customMetadata) : filename_(filename),
                                                       schema_(schema),
                                                       encoderPtr_(binaryEncoder()),
                                                       syncInterval_(syncInterval),
@@ -74,11 +76,11 @@ DataFileWriterBase::DataFileWriterBase(const char *filename, const ValidSchema &
                                                       sync_(makeSync()),
                                                       objectCount_(0),
                                                       lastSync_(0) {
-    init(schema, syncInterval, codec);
+    init(schema, syncInterval, codec, customMetadata);
 }
 
 DataFileWriterBase::DataFileWriterBase(std::unique_ptr<OutputStream> outputStream,
-                                       const ValidSchema &schema, size_t syncInterval, Codec codec) : filename_(),
+                                       const ValidSchema &schema, size_t syncInterval, Codec codec, const std::map<std::string, std::string> &customMetadata) : filename_(),
                                                                                                       schema_(schema),
                                                                                                       encoderPtr_(binaryEncoder()),
                                                                                                       syncInterval_(syncInterval),
@@ -88,10 +90,10 @@ DataFileWriterBase::DataFileWriterBase(std::unique_ptr<OutputStream> outputStrea
                                                                                                       sync_(makeSync()),
                                                                                                       objectCount_(0),
                                                                                                       lastSync_(0) {
-    init(schema, syncInterval, codec);
+    init(schema, syncInterval, codec, customMetadata);
 }
 
-void DataFileWriterBase::init(const ValidSchema &schema, size_t syncInterval, const Codec &codec) {
+void DataFileWriterBase::init(const ValidSchema &schema, size_t syncInterval, const Codec &codec, const std::map<std::string, std::string> &customMetadata) {
     if (syncInterval < minSyncInterval || syncInterval > maxSyncInterval) {
         throw Exception(boost::format("Invalid sync interval: %1%. "
                                       "Should be between %2% and %3%")
@@ -111,6 +113,9 @@ void DataFileWriterBase::init(const ValidSchema &schema, size_t syncInterval, co
         throw Exception(boost::format("Unknown codec: %1%") % codec);
     }
     setMetadata(AVRO_SCHEMA_KEY, schema.toJson(false));
+    for (const auto &kv : customMetadata) {
+        setMetadata(kv.first, kv.second);
+    }
 
     writeHeader();
     encoderPtr_->init(*buffer_);
@@ -560,6 +565,14 @@ bool DataFileReaderBase::pastSync(int64_t position) {
 
 int64_t DataFileReaderBase::previousSync() const {
     return blockStart_;
+}
+
+std::optional<std::string> DataFileReaderBase::getMetadata(const std::string& key) {
+    if (auto it = metadata_.find(key); it == metadata_.cend()) {
+        return std::nullopt;
+    } else {
+        return std::string(it->second.cbegin(), it->second.cend());
+    }
 }
 
 } // namespace avro

--- a/lang/c++/impl/LogicalType.cc
+++ b/lang/c++/impl/LogicalType.cc
@@ -77,6 +77,9 @@ void LogicalType::printJson(std::ostream &os) const {
         case UUID:
             os << R"("logicalType": "uuid")";
             break;
+        case MAP:
+            os << R"("logicalType": "map")";
+            break;
     }
 }
 

--- a/lang/c++/impl/Node.cc
+++ b/lang/c++/impl/Node.cc
@@ -142,6 +142,12 @@ void Node::setLogicalType(LogicalType logicalType) {
                                 "STRING type");
             }
             break;
+        case LogicalType::MAP:
+            if (type_ != AVRO_ARRAY) {
+                throw Exception("MAP logical type can only annotate "
+                                "ARRAY type");
+            }
+            break;
     }
 
     logicalType_ = logicalType;

--- a/lang/c++/impl/NodeImpl.cc
+++ b/lang/c++/impl/NodeImpl.cc
@@ -519,6 +519,11 @@ void NodeArray::printJson(std::ostream &os, size_t depth) const {
         os << indent(depth + 1) << R"("doc": ")"
            << escape(getDoc()) << "\",\n";
     }
+    if (logicalType().type() != LogicalType::NONE) {
+        os << indent(depth);
+        logicalType().printJson(os);
+        os << ",\n";
+    }
     os << indent(depth + 1) << "\"items\": ";
     leafAttributes_.get()->printJson(os, depth + 1);
     os << '\n';

--- a/lang/c++/impl/NodeImpl.cc
+++ b/lang/c++/impl/NodeImpl.cc
@@ -524,6 +524,10 @@ void NodeArray::printJson(std::ostream &os, size_t depth) const {
         logicalType().printJson(os);
         os << ",\n";
     }
+    if (!elementId_.empty()) {
+        os << indent(depth + 1) << R"("element-id": ")"
+           << escape(elementId_) << "\",\n";
+    }
     os << indent(depth + 1) << "\"items\": ";
     leafAttributes_.get()->printJson(os, depth + 1);
     os << '\n';

--- a/lang/c++/include/avro/LogicalType.hh
+++ b/lang/c++/include/avro/LogicalType.hh
@@ -36,7 +36,8 @@ public:
         TIMESTAMP_MILLIS,
         TIMESTAMP_MICROS,
         DURATION,
-        UUID
+        UUID,
+        MAP
     };
 
     explicit LogicalType(Type type);

--- a/lang/c++/include/avro/NodeImpl.hh
+++ b/lang/c++/include/avro/NodeImpl.hh
@@ -416,6 +416,8 @@ public:
     }
 
     void printDefaultToJson(const GenericDatum &g, std::ostream &os, size_t depth) const override;
+
+    std::string elementId_;
 };
 
 class AVRO_DECL NodeMap : public NodeImplMap {

--- a/lang/c++/test/DataFileTests.cc
+++ b/lang/c++/test/DataFileTests.cc
@@ -658,6 +658,26 @@ public:
             BOOST_CHECK_EQUAL(root->leafAt(5)->getDoc(), "extra slashes\\\\");
         }
     }
+
+    void testWriteCustomMetadata() {
+        uint32_t a = 42;
+        {
+            avro::DataFileWriter<uint32_t> df(filename, writerSchema, 16 * 1024, avro::NULL_CODEC, {{"test_key_1", "test_value_1"}, {"test_key_2", "test_value_2"}});
+            df.write(a);
+        }
+
+        {
+
+            avro::DataFileReader<uint32_t> df(filename);
+            auto val_1 = df.getMetadata("test_key_1");
+            BOOST_CHECK(val_1.has_value());
+            BOOST_CHECK_EQUAL(val_1.value(), "test_value_1");
+
+            auto val_2 = df.getMetadata("test_key_2");
+            BOOST_CHECK(val_2.has_value());
+            BOOST_CHECK_EQUAL(val_2.value(), "test_value_2");
+        }
+    }
 };
 
 void addReaderTests(test_suite *ts, const shared_ptr<DataFileTest> &t) {
@@ -1122,6 +1142,15 @@ init_unit_test_suite(int argc, char *argv[]) {
         shared_ptr<DataFileTest> t(new DataFileTest("test12.df", ischWithDoc, ischWithDoc));
         ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testWrite, t));
         ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testSchemaReadWriteWithDoc, t));
+        ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testCleanup, t));
+        boost::unit_test::framework::master_test_suite().add(ts);
+    }
+
+    {
+        auto *ts = BOOST_TEST_SUITE("DataFile tests: test13.df");
+        shared_ptr<DataFileTest> t(new DataFileTest("test13.df", ischWithDoc, ischWithDoc));
+        ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testWrite, t));
+        ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testWriteCustomMetadata, t));
         ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testCleanup, t));
         boost::unit_test::framework::master_test_suite().add(ts);
     }

--- a/lang/c++/test/SchemaTests.cc
+++ b/lang/c++/test/SchemaTests.cc
@@ -199,6 +199,7 @@ const char *roundTripSchemas[] = {
     R"({"type":"array","items":"long"})",
     "{\"type\":\"array\",\"items\":{\"type\":\"enum\","
     "\"name\":\"Test\",\"symbols\":[\"A\",\"B\"]}}",
+    R"({"type":"array","element-id":"testElemId","items":"long"})",
 
     // Map
     R"({"type":"map","values":"long"})",

--- a/lang/c++/test/SchemaTests.cc
+++ b/lang/c++/test/SchemaTests.cc
@@ -380,6 +380,26 @@ static void testLogicalTypes() {
     const char* unionType = "[\n\
         {\"type\":\"string\", \"logicalType\":\"uuid\"},\"null\"\n\
     ]";
+    const char* arrayMapType = R"({
+        "type": "array",
+        "logicalType": "map",
+        "items": {
+            "type": "record",
+            "name": "k1_v2",
+            "fields": [
+            {
+                "name": "key",
+                "type": "int",
+                "field-id": "1"
+            },
+            {
+                "name": "value",
+                "type": "long",
+                "field-id": "2"
+            }
+            ]
+        }
+    })";
     {
         BOOST_TEST_CHECKPOINT(bytesDecimalType);
         ValidSchema schema1 = compileJsonSchemaFromString(bytesDecimalType);
@@ -473,6 +493,15 @@ static void testLogicalTypes() {
         BOOST_CHECK(logicalType.type() == LogicalType::NONE);
         GenericDatum datum(schema);
         BOOST_CHECK(datum.logicalType().type() == LogicalType::UUID);
+    }
+    {
+        BOOST_TEST_CHECKPOINT(arrayMapType);
+        ValidSchema schema = compileJsonSchemaFromString(arrayMapType);
+        BOOST_CHECK(schema.root()->type() == AVRO_ARRAY);
+        LogicalType logicalType = schema.root()->logicalType();
+        BOOST_CHECK(logicalType.type() == LogicalType::MAP);
+        GenericDatum datum(schema);
+        BOOST_CHECK(datum.logicalType().type() == LogicalType::MAP);
     }
 }
 


### PR DESCRIPTION
https://redpandadata.atlassian.net/browse/CORE-5087

Adds some missing features to the Avro C++ implementation to support Iceberg development:
- Custom metadata in Avro files.
- `map` as a logical type for arrays.
- `element-id` field for arrays.

My somewhat limited reading of the Java Iceberg implementation and the Java Avro implementation suggest that Java Iceberg is relying on _custom properties_ (called _custom attributes_ or _custom fields_ in C++) for the "element-id". In Java Avro, custom properties can be any type, not just strings. In the future we may want to change the way custom properties/attributes work in C++ Avro, rather than having element-id be a special case for Iceberg.

More info about open questions related to this PR: https://docs.google.com/document/d/13Nh-01cTWU0cRoo-SqncqviG3oQBX8lp-Vt6oLWcqwo/edit