### PR TITLE
upstream fixes for empty records in avrocppgen

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -156,6 +156,7 @@ gen (tweet testgen3)
 gen (union_array_union uau)
 gen (union_map_union umu)
 gen (union_conflict uc)
+gen (union_empty_record uer)
 gen (recursive rec)
 gen (reuse ru)
 gen (circulardep cd)
@@ -197,7 +198,8 @@ add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
     tweet_hh
     union_array_union_hh union_map_union_hh union_conflict_hh
     recursive_hh reuse_hh circulardep_hh tree1_hh tree2_hh crossref_hh
-    primitivetypes_hh empty_record_hh cpp_reserved_words_union_typedef_hh)
+    primitivetypes_hh empty_record_hh cpp_reserved_words_union_typedef_hh
+    union_empty_record_hh)
 
 include (InstallRequiredSystemLibraries)
 

--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -143,7 +143,7 @@ macro (gen file ns)
         COMMAND avrogencpp
             -p -
             -i ${CMAKE_CURRENT_SOURCE_DIR}/jsonschemas/${file}
-            -o ${file}.hh -n ${ns} -U
+            -o ${file}.hh -n ${ns}
         DEPENDS avrogencpp ${CMAKE_CURRENT_SOURCE_DIR}/jsonschemas/${file})
     add_custom_target (${file}_hh DEPENDS ${file}.hh)
 endmacro (gen)
@@ -164,6 +164,7 @@ gen (tree2 tr2)
 gen (crossref cr)
 gen (primitivetypes pt)
 gen (cpp_reserved_words cppres)
+gen (cpp_reserved_words_union_typedef cppres_union)
 
 add_executable (avrogencpp impl/avrogencpp.cc)
 target_link_libraries (avrogencpp avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
@@ -196,7 +197,7 @@ add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
     tweet_hh
     union_array_union_hh union_map_union_hh union_conflict_hh
     recursive_hh reuse_hh circulardep_hh tree1_hh tree2_hh crossref_hh
-    primitivetypes_hh empty_record_hh)
+    primitivetypes_hh empty_record_hh cpp_reserved_words_union_typedef_hh)
 
 include (InstallRequiredSystemLibraries)
 

--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -250,6 +250,7 @@ string CodeGen::generateRecordType(const NodePtr &n) {
             if (n->leafAt(i)->type() == avro::AVRO_UNION) {
                 os_ << "    typedef " << types[i]
                     << ' ' << n->nameAt(i) << "_t;\n";
+                types[i] = n->nameAt(i) + "_t";
             }
         }
     }
@@ -257,11 +258,7 @@ string CodeGen::generateRecordType(const NodePtr &n) {
         // the nameAt(i) does not take c++ reserved words into account
         // so we need to call decorate on it
         std::string decoratedNameAt = decorate(n->nameAt(i));
-        if (!noUnion_ && n->leafAt(i)->type() == avro::AVRO_UNION) {
-            os_ << "    " << decoratedNameAt << "_t";
-        } else {
-            os_ << "    " << types[i];
-        }
+        os_ << "    " << types[i];
         os_ << ' ' << decoratedNameAt << ";\n";
     }
 
@@ -275,13 +272,7 @@ string CodeGen::generateRecordType(const NodePtr &n) {
         // so we need to call decorate on it
         std::string decoratedNameAt = decorate(n->nameAt(i));
         os_ << "        " << decoratedNameAt << "(";
-        if (!noUnion_ && n->leafAt(i)->type() == avro::AVRO_UNION) {
-            // the nameAt(i) does not take c++ reserved words into account
-            // so we need to call decorate on it
-            os_ << decoratedNameAt << "_t";
-        } else {
-            os_ << types[i];
-        }
+        os_ << types[i];
         os_ << "())";
         if (i != (c - 1)) {
             os_ << ',';

--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -252,6 +252,10 @@ string CodeGen::generateRecordType(const NodePtr &n) {
                     << ' ' << n->nameAt(i) << "_t;\n";
                 types[i] = n->nameAt(i) + "_t";
             }
+            if (n->leafAt(i)->type() == avro::AVRO_ARRAY && n->leafAt(i)->leafAt(0)->type() == avro::AVRO_UNION) {
+                os_ << "    typedef " << types[i] << "::value_type"
+                    << ' ' << n->nameAt(i) << "_item_t;\n";
+            }
         }
     }
     for (size_t i = 0; i < c; ++i) {
@@ -542,8 +546,22 @@ void CodeGen::generateRecordTraits(const NodePtr &n) {
     }
 
     string fn = fullname(decorate(n->name()));
-    os_ << "template<> struct codec_traits<" << fn << "> {\n"
-        << "    static void encode(Encoder& e, const " << fn << "& v) {\n";
+    os_ << "template<> struct codec_traits<" << fn << "> {\n";
+
+    if (c == 0) {
+        os_ << "    static void encode(Encoder&, const " << fn << "&) {}\n";
+        // ResolvingDecoder::fieldOrder mutates the state of the decoder, so if that decoder is
+        // passed in, we need to call the method even though it will return an empty vector.
+        os_ << "    static void decode(Decoder& d, " << fn << "&) {\n";
+        os_ << "        if (avro::ResolvingDecoder *rd = dynamic_cast<avro::ResolvingDecoder *>(&d)) {\n";
+        os_ << "            rd->fieldOrder();\n";
+        os_ << "        }\n";
+        os_ << "    }\n";
+        os_ << "};\n";
+        return;
+    }
+
+    os_ << "    static void encode(Encoder& e, const " << fn << "& v) {\n";
 
     for (size_t i = 0; i < c; ++i) {
         // the nameAt(i) does not take c++ reserved words into account

--- a/lang/c++/impl/parsing/ValidatingCodec.cc
+++ b/lang/c++/impl/parsing/ValidatingCodec.cc
@@ -502,6 +502,7 @@ void ValidatingEncoder<P>::setItemCount(size_t count) {
 
 template<typename P>
 void ValidatingEncoder<P>::startItem() {
+    parser_.processImplicitActions();
     if (parser_.top() != Symbol::Kind::Repeater) {
         throw Exception("startItem at not an item boundary");
     }

--- a/lang/c++/jsonschemas/cpp_reserved_words_union_typedef
+++ b/lang/c++/jsonschemas/cpp_reserved_words_union_typedef
@@ -1,0 +1,13 @@
+{
+  "type": "record",
+  "name": "Record",
+  "fields": [
+    {
+      "name": "void",
+      "type": [
+        "int",
+        "double"
+      ]
+    }
+  ]
+}

--- a/lang/c++/jsonschemas/union_empty_record
+++ b/lang/c++/jsonschemas/union_empty_record
@@ -1,0 +1,25 @@
+{
+  "type": "record",
+  "name": "StackCalculator",
+  "fields": [
+    {
+      "name": "stack",
+      "type": {
+        "type": "array",
+        "items": [
+          "int",
+          {
+            "type": "record",
+            "name": "Dup",
+            "fields": []
+          },
+          {
+            "type": "record",
+            "name": "Add",
+            "fields": []
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/lang/c++/test/AvrogencppTestReservedWords.cc
+++ b/lang/c++/test/AvrogencppTestReservedWords.cc
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 #include "cpp_reserved_words.hh"
+#include "cpp_reserved_words_union_typedef.hh"
 
 #include "Compiler.hh"
 


### PR DESCRIPTION
Pulls in:
- https://github.com/apache/avro/pull/2927: required by Iceberg because the Iceberg schema we're using has an empty partition record for some reason
- https://github.com/apache/avro/pull/2930: pulled this one in because it seems harmless and helped resolve a conflict when cherry-picking the above

Before, we would see errors like:
```
src/v/iceberg/manifest_entry.h:613:33: error: unused parameter 'e' [-Werror,-Wunused-parameter]
    static void encode(Encoder& e, const iceberg::r102& v) {
                                ^
src/v/iceberg/manifest_entry.h:613:57: error: unused parameter 'v' [-Werror,-Wunused-parameter]
    static void encode(Encoder& e, const iceberg::r102& v) {
                                                        ^
src/v/iceberg/manifest_entry.h:615:51: error: unused parameter 'v' [-Werror,-Wunused-parameter]
    static void decode(Decoder& d, iceberg::r102& v) {
                                                  ^
3 errors generated.
```

The generated code now looks like:

```
template<> struct codec_traits<iceberg::r102> {
    static void encode(Encoder&, const iceberg::r102&) {}
    static void decode(Decoder& d, iceberg::r102&) {
        if (avro::ResolvingDecoder *rd = dynamic_cast<avro::ResolvingDecoder *>(&d)) {
            rd->fieldOrder();
        }
    }
};
```
