### PR TITLE
redpanda_build: add avrogencpp to RP build

### DIFF
--- a/redpanda_build/CMakeLists.txt
+++ b/redpanda_build/CMakeLists.txt
@@ -48,3 +48,6 @@ target_include_directories(avro
   PRIVATE ../lang/c++/include/avro)
 
 add_library(Avro::avro ALIAS avro)
+
+add_executable (avrogencpp impl/avrogencpp.cc)
+target_link_libraries (avrogencpp avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})


### PR DESCRIPTION
The Redpanda open-source build relies on thirdparty projects having a redpanda_build directory with custom CMake files. Updates this file to include the avrogencpp binary.
