### PR TITLE
Revert "redpanda_build: add avrogencpp to RP build"

### DIFF
--- a/redpanda_build/CMakeLists.txt
+++ b/redpanda_build/CMakeLists.txt
@@ -48,6 +48,3 @@ target_include_directories(avro
   PRIVATE ../lang/c++/include/avro)
 
 add_library(Avro::avro ALIAS avro)
-
-add_executable (avrogencpp impl/avrogencpp.cc)
-target_link_libraries (avrogencpp avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})


### PR DESCRIPTION
This reverts commit bc2e637afd84076dee8f3eb38dd794ea2b988f6e.

```
CMake Error at build/release-ci/_deps/avro-src/redpanda_build/CMakeLists.txt:52 (add_executable):
  Cannot find source file:
    impl/avrogencpp.cc
```