### PR TITLE
Iceberg fixes pt 2

### DIFF
--- a/lang/c++/impl/Compiler.cc
+++ b/lang/c++/impl/Compiler.cc
@@ -427,7 +427,7 @@ static NodePtr makeArrayNode(const Entity &e, const Object &m,
         asSingleAttribute(makeNode(it->second, st, ns)));
     NodePtr node = NodePtr(nodePointer);
     if (containsField(m, "element-id")) {
-        nodePointer->elementId_ = getStringField(e, m, "element-id");
+        nodePointer->elementId_ = getLongField(e, m, "element-id");
     }
     if (containsField(m, "doc")) {
         node->setDoc(getDocField(e, m));

--- a/lang/c++/impl/NodeImpl.cc
+++ b/lang/c++/impl/NodeImpl.cc
@@ -524,9 +524,9 @@ void NodeArray::printJson(std::ostream &os, size_t depth) const {
         logicalType().printJson(os);
         os << ",\n";
     }
-    if (!elementId_.empty()) {
-        os << indent(depth + 1) << R"("element-id": ")"
-           << escape(elementId_) << "\",\n";
+    if (elementId_.has_value()) {
+        os << indent(depth + 1) << "\"element-id\": "
+           << *elementId_ << ",\n";
     }
     os << indent(depth + 1) << "\"items\": ";
     leafAttributes_.get()->printJson(os, depth + 1);

--- a/lang/c++/impl/parsing/JsonCodec.cc
+++ b/lang/c++/impl/parsing/JsonCodec.cc
@@ -496,6 +496,7 @@ public:
 template<typename P, typename F>
 void JsonEncoder<P, F>::init(OutputStream &os) {
     out_.init(os);
+    parser_.reset();
 }
 
 template<typename P, typename F>

--- a/lang/c++/include/avro/NodeImpl.hh
+++ b/lang/c++/include/avro/NodeImpl.hh
@@ -26,6 +26,7 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <utility>
@@ -417,7 +418,7 @@ public:
 
     void printDefaultToJson(const GenericDatum &g, std::ostream &os, size_t depth) const override;
 
-    std::string elementId_;
+    std::optional<int64_t> elementId_;
 };
 
 class AVRO_DECL NodeMap : public NodeImplMap {

--- a/lang/c++/test/CodecTests.cc
+++ b/lang/c++/test/CodecTests.cc
@@ -963,6 +963,11 @@ static const TestData data[] = {
     {R"({"type":"map", "values": "boolean"})",
      "{c1sK5Bc2sK5BsK5B}", 2},
 
+    // Record with no fields
+    {"{\"type\":\"record\",\"name\":\"empty\",\"fields\":[]}",
+     "", 1},
+
+    // Single-field records
     {"{\"type\":\"record\",\"name\":\"r\",\"fields\":["
      "{\"name\":\"f\", \"type\":\"boolean\"}]}",
      "B", 1},
@@ -1002,6 +1007,16 @@ static const TestData data[] = {
      "{\"name\":\"f7\", \"type\":\"bytes\"}]}",
      "NBILFDS10b25", 1},
     // record of records
+    {"{\"type\":\"record\",\"name\":\"r\",\"fields\":["
+     "{\"name\":\"f1\",\"type\":\"boolean\"},"
+     "{\"name\":\"f2\", \"type\":{\"type\":\"record\","
+     "\"name\":\"inner\",\"fields\":[]}}]}",
+     "B", 1},
+    {"{\"type\":\"record\",\"name\":\"r\",\"fields\":["
+     "{\"name\":\"f1\",\"type\":\"boolean\"},"
+     "{\"name\":\"f2\", \"type\":{\"type\":\"array\","
+     "\"items\":\"r\"}}]}",
+     "B[]", 1},
     {"{\"type\":\"record\",\"name\":\"outer\",\"fields\":["
      "{\"name\":\"f1\", \"type\":{\"type\":\"record\", "
      "\"name\":\"inner\", \"fields\":["

--- a/lang/c++/test/SchemaTests.cc
+++ b/lang/c++/test/SchemaTests.cc
@@ -199,7 +199,7 @@ const char *roundTripSchemas[] = {
     R"({"type":"array","items":"long"})",
     "{\"type\":\"array\",\"items\":{\"type\":\"enum\","
     "\"name\":\"Test\",\"symbols\":[\"A\",\"B\"]}}",
-    R"({"type":"array","element-id":"testElemId","items":"long"})",
+    R"({"type":"array","element-id":42,"items":"long"})",
 
     // Map
     R"({"type":"map","values":"long"})",

--- a/redpanda_build/CMakeLists.txt
+++ b/redpanda_build/CMakeLists.txt
@@ -1,12 +1,26 @@
 cmake_minimum_required(VERSION 3.22)
 project(avro)
 
+if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../VERSION.txt)
+    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/../VERSION.txt" AVRO_VERSION)
+else (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../VERSION.txt)
+    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/../share/VERSION.txt"
+        AVRO_VERSION)
+endif (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../VERSION.txt)
+
+string(REPLACE "\n" "" AVRO_VERSION  ${AVRO_VERSION})
+string(REPLACE "." ";" AVRO_VERSION  ${AVRO_VERSION})
+list(GET AVRO_VERSION 0 AVRO_VERSION_MAJOR)
+list(GET AVRO_VERSION 1 AVRO_VERSION_MINOR)
+list(GET AVRO_VERSION 2 AVRO_VERSION_PATCH)
+add_definitions (-DAVRO_VERSION="${AVRO_VERSION_MAJOR}.${AVRO_VERSION_MINOR}.${AVRO_VERSION_PATCH}")
+
 list(APPEND CMAKE_MODULE_PATH ../lang/c++/cmake)
 
 find_package(Snappy)
 
 find_package (Boost 1.74 REQUIRED
-  COMPONENTS iostreams system)
+  COMPONENTS iostreams system program_options regex)
 
 add_library(avro
   ../lang/c++/impl/Compiler.cc
@@ -48,3 +62,7 @@ target_include_directories(avro
   PRIVATE ../lang/c++/include/avro)
 
 add_library(Avro::avro ALIAS avro)
+
+add_executable (avrogencpp ../lang/c++/impl/avrogencpp.cc)
+target_include_directories(avrogencpp PRIVATE ../lang/c++/include/avro)
+target_link_libraries (avrogencpp avro ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})


### PR DESCRIPTION
Adds a couple fixes for Iceberg:
- another cherry-pick from the apache main branch, #2833 which I noticed was causing a test failure
- follow-up to the recent introduction of element-id to read them in as a long, as we expect in our manifest schemas
- follow-up to the recent update/revert to the redpanda build to build avrogencpp