### PR TITLE
avrogencpp: expose ValidSchema in generated code

### DIFF
--- a/lang/c++/test/AvrogencppTests.cc
+++ b/lang/c++/test/AvrogencppTests.cc
@@ -247,19 +247,15 @@ const char schemaFilename<umu::r1>::value[] = "jsonschemas/union_map_union";
 
 template<typename T>
 void testEncoding2() {
-    ValidSchema s;
-    ifstream ifs(schemaFilename<T>::value);
-    compileJsonSchema(ifs, s);
-
     unique_ptr<OutputStream> os = memoryOutputStream();
-    EncoderPtr e = validatingEncoder(s, binaryEncoder());
+    EncoderPtr e = validatingEncoder(T::valid_schema(), binaryEncoder());
     e->init(*os);
     T t1;
     setRecord(t1);
     avro::encode(*e, t1);
     e->flush();
 
-    DecoderPtr d = validatingDecoder(s, binaryDecoder());
+    DecoderPtr d = validatingDecoder(T::valid_schema(), binaryDecoder());
     unique_ptr<InputStream> is = memoryInputStream(*os);
     d->init(*is);
     T t2;


### PR DESCRIPTION
The C++ avro library has readers and writers that depend on having an in-memory ValidSchema. The avrogencpp tool can take a JSON schema and generate code to interact with a given datum, but doesn't expose the ValidSchema, despite using it during codegen.

This adds a valid_schema() method to the avrogencpp binary that builds the schema and exposes it via generated code.

This is inspired largely by the kspp[1] library.

Note, the escape() method used is copied from [2].

[1] https://github.com/bitbouncer/kspp/blob/8539f359e32bd3dd1360ac4616eab88e79aab607/tools/kspp_avrogencpp/kspp_avrogencpp.cpp
[2] https://github.com/redpanda-data/avro/blob/1410e79f9df61669c2d52f6d0643e6c35156e615/lang/c%2B%2B/impl/NodeImpl.cc#L29-L69

