### PR TITLE
C++: add elementId to programmatic API

### DIFF
--- a/lang/c++/impl/Schema.cc
+++ b/lang/c++/impl/Schema.cc
@@ -65,6 +65,10 @@ ArraySchema::ArraySchema(const ArraySchema &itemsSchema) : Schema(std::make_shar
     node_->addLeaf(itemsSchema.root());
 }
 
+ArraySchema::ArraySchema(const Schema &itemsSchema, int64_t elementId) : Schema(std::make_shared<NodeArray>(elementId)) {
+    node_->addLeaf(itemsSchema.root());
+}
+
 MapSchema::MapSchema(const Schema &valuesSchema) : Schema(std::make_shared<NodeMap>()) {
     node_->addLeaf(valuesSchema.root());
 }

--- a/lang/c++/include/avro/NodeImpl.hh
+++ b/lang/c++/include/avro/NodeImpl.hh
@@ -405,6 +405,7 @@ public:
 class AVRO_DECL NodeArray : public NodeImplArray {
 public:
     NodeArray() : NodeImplArray(AVRO_ARRAY) {}
+    explicit NodeArray(int64_t elementId) : NodeImplArray(AVRO_ARRAY), elementId_(elementId) {}
 
     explicit NodeArray(const SingleLeaf &items) : NodeImplArray(AVRO_ARRAY, NoName(), items, NoLeafNames(), NoAttributes(), NoSize()) {}
 

--- a/lang/c++/include/avro/Schema.hh
+++ b/lang/c++/include/avro/Schema.hh
@@ -118,6 +118,7 @@ public:
 class AVRO_DECL ArraySchema : public Schema {
 public:
     explicit ArraySchema(const Schema &itemsSchema);
+    ArraySchema(const Schema &itemsSchema, int64_t elementId);
     ArraySchema(const ArraySchema &itemsSchema);
 };
 

--- a/lang/c++/test/unittest.cc
+++ b/lang/c++/test/unittest.cc
@@ -1084,6 +1084,26 @@ void testNestedMapSchema() {
     BOOST_CHECK_EQUAL(expected, actual.str());
 }
 
+void testArraySchemaElementId() {
+    ArraySchema b0 = ArraySchema(NullSchema(), 2);
+    ArraySchema a0 = ArraySchema(b0, 1);
+
+    avro::ValidSchema vs(a0);
+    std::ostringstream actual;
+    vs.toJson(actual);
+
+    std::string expected = "{\n\
+    \"type\": \"array\",\n\
+    \"element-id\": 1,\n\
+    \"items\": {\n\
+        \"type\": \"array\",\n\
+        \"element-id\": 2,\n\
+        \"items\": \"null\"\n\
+    }\n\
+}\n";
+    BOOST_CHECK_EQUAL(expected, actual.str());
+}
+
 boost::unit_test::test_suite *
 init_unit_test_suite(int /*argc*/, char * /*argv*/[]) {
     using namespace boost::unit_test;
@@ -1104,6 +1124,7 @@ init_unit_test_suite(int /*argc*/, char * /*argv*/[]) {
                                     boost::make_shared<TestResolution>()));
     test->add(BOOST_TEST_CASE(&testNestedArraySchema));
     test->add(BOOST_TEST_CASE(&testNestedMapSchema));
+    test->add(BOOST_TEST_CASE(&testArraySchemaElementId));
 
     return test;
 }


### PR DESCRIPTION
A previous commit added a "element-id" attribute to arrays, which will be used in Iceberg manifests. This was previously only available when parsing a schema JSON file, not via the programmatic API.

The way that Redpanda will build Iceberg manifests is going to change to use the programmatic API, in order to support some fields of the manifest that have a dynamic schema. To that end, this exposes the "element-id" via a new constructor for ArraySchemas.
