### PR TITLE
C++: accessors for custom attributes

### DIFF
--- a/lang/c++/include/avro/Node.hh
+++ b/lang/c++/include/avro/Node.hh
@@ -160,6 +160,9 @@ public:
         doAddCustomAttribute(customAttributes);
     }
 
+    virtual size_t customAttributes() const = 0;
+    virtual const CustomAttributes& customAttributesAt(size_t index) const = 0;
+
     virtual bool isValid() const = 0;
 
     virtual SchemaResolution resolve(const Node &reader) const = 0;

--- a/lang/c++/include/avro/NodeImpl.hh
+++ b/lang/c++/include/avro/NodeImpl.hh
@@ -147,6 +147,14 @@ protected:
         return nameIndex_.lookup(name, index);
     }
 
+    size_t customAttributes() const override {
+        return customAttributes_.size();
+    }
+
+    const CustomAttributes& customAttributesAt(size_t index) const override {
+        return customAttributes_.get(index);
+    }
+
     void doSetFixedSize(size_t size) override {
         sizeAttribute_.add(size);
     }


### PR DESCRIPTION
Custom attributes are only settable when building a schema. There was previously no way to get the attributes from a parsed schema. This will be useful for reading Iceberg manifests, since we'll want to pull the field ids for each type.