### PR TITLE
C++: add default value when building schemas

### DIFF
--- a/lang/c++/impl/Schema.cc
+++ b/lang/c++/impl/Schema.cc
@@ -33,6 +33,12 @@ void RecordSchema::addField(const std::string &name, const Schema &fieldSchema) 
 }
 
 void RecordSchema::addField(const std::string &name, const Schema &fieldSchema, const CustomAttributes &customFields) {
+    // NOTE: GenericDatum() is the value used when compiling a schema if there
+    // is no default.
+    addField(name, fieldSchema, customFields, GenericDatum());
+}
+
+void RecordSchema::addField(const std::string &name, const Schema &fieldSchema, const CustomAttributes &customFields, const GenericDatum &fieldDefault) {
     // add the name first. it will throw if the name is a duplicate, preventing
     // the leaf from being added
     node_->addName(name);
@@ -40,6 +46,8 @@ void RecordSchema::addField(const std::string &name, const Schema &fieldSchema, 
     node_->addLeaf(fieldSchema.root());
 
     node_->addCustomAttributesForField(customFields);
+
+    node_->addDefaultForField(fieldDefault);
 }
 
 std::string RecordSchema::getDoc() const {

--- a/lang/c++/include/avro/Node.hh
+++ b/lang/c++/include/avro/Node.hh
@@ -167,6 +167,10 @@ public:
         checkLock();
         doAddCustomAttribute(customAttributes);
     }
+    void addDefaultForField(const GenericDatum &fieldDefault) {
+        checkLock();
+        doAddDefault(fieldDefault);
+    }
 
     virtual size_t customAttributes() const = 0;
     virtual const CustomAttributes& customAttributesAt(size_t index) const = 0;
@@ -208,6 +212,7 @@ protected:
     virtual void doAddName(const std::string &name) = 0;
     virtual void doSetFixedSize(size_t size) = 0;
     virtual void doAddCustomAttribute(const CustomAttributes &customAttributes) = 0;
+    virtual void doAddDefault(const GenericDatum &fieldDefault) = 0;
 
 private:
     const Type type_;

--- a/lang/c++/include/avro/NodeImpl.hh
+++ b/lang/c++/include/avro/NodeImpl.hh
@@ -172,7 +172,9 @@ protected:
     void doAddCustomAttribute(const CustomAttributes &customAttributes) override {
         customAttributes_.add(customAttributes);
     }
-
+    void doAddDefault(const GenericDatum &) override {
+        throw Exception("Default only permitted for records");
+    }
     SchemaResolution furtherResolution(const Node &reader) const {
         SchemaResolution match = RESOLVE_NO_MATCH;
 
@@ -340,6 +342,10 @@ public:
     const GenericDatum &defaultValueAt(size_t index) const override {
         return fieldsDefaultValues_[index];
     }
+    void doAddDefault(const GenericDatum &fieldDefault) override {
+        fieldsDefaultValues_.push_back(fieldDefault);
+    }
+
 
     void printDefaultToJson(const GenericDatum &g, std::ostream &os, size_t depth) const override;
 };

--- a/lang/c++/include/avro/Schema.hh
+++ b/lang/c++/include/avro/Schema.hh
@@ -104,6 +104,10 @@ public:
     // Add a field with custom attributes
     void addField(const std::string &name, const Schema &fieldSchema,
                   const CustomAttributes &customAttributes);
+    // Add a field with a field default
+    void addField(const std::string &name, const Schema &fieldSchema,
+                  const CustomAttributes &customAttributes,
+                  const GenericDatum &fieldDefault);
 
     std::string getDoc() const;
     void setDoc(const std::string &);


### PR DESCRIPTION
The default value of a schema is important to know when trying to parse data records that have missing values.

Avro's JSON-compiling schema builder constructs a GenericDatum from type the provided in the schema[1]: When there is no default provided in the schema, the default datum is GenericDatum(). Otherwise, it's a datum of the type desired by the schema, constructed with values pulled from the schema.

In my immediate use case (Iceberg manifest entries) most fields have no default values, but union types will have a default of null, in which case the caller will need to pass in a GenericDatum containing a GenericUnion.

This introduces some interfaces to the RecordSchema::addField() method to allow the addition of defaults to fields.

[1] https://github.com/redpanda-data/avro/blob/3bbe74853f8cd3184272aa7c130b3cab45828f62/lang/c%2B%2B/impl/Compiler.cc#L301
