### PR TITLE
CORE-1796 c++: improve default field representation

### DIFF
--- a/lang/c++/impl/Compiler.cc
+++ b/lang/c++/impl/Compiler.cc
@@ -149,10 +149,10 @@ struct Field {
     const string name;
     const vector<string> aliases;
     const NodePtr schema;
-    const GenericDatum defaultValue;
+    const std::optional<GenericDatum> defaultValue;
     const CustomAttributes customAttributes;
 
-    Field(string n, vector<string> a, NodePtr v, GenericDatum dv, const CustomAttributes &ca)
+    Field(string n, vector<string> a, NodePtr v, std::optional<GenericDatum> dv, const CustomAttributes &ca)
         : name(std::move(n)), aliases(std::move(a)), schema(std::move(v)), defaultValue(std::move(dv)), customAttributes(ca) {}
 };
 
@@ -298,7 +298,7 @@ static Field makeField(const Entity &e, SymbolTable &st, const string &ns) {
     if (containsField(m, "doc")) {
         node->setDoc(getDocField(e, m));
     }
-    GenericDatum d = (it2 == m.end()) ? GenericDatum() : makeGenericDatum(node, it2->second, st);
+    std::optional<GenericDatum> d = (it2 == m.end()) ? std::optional<GenericDatum>{} : makeGenericDatum(node, it2->second, st);
     // Get custom attributes
     CustomAttributes customAttributes;
     getCustomAttributes(m, customAttributes);
@@ -313,7 +313,7 @@ static NodePtr makeRecordNode(const Entity &e, const Name &name,
     vector<vector<string>> fieldAliases;
     concepts::MultiAttribute<NodePtr> fieldValues;
     concepts::MultiAttribute<CustomAttributes> customAttributes;
-    vector<GenericDatum> defaultValues;
+    vector<std::optional<GenericDatum>> defaultValues;
     string fields = "fields";
     for (const auto &it : getArrayField(e, m, fields)) {
         Field f = makeField(it, st, ns);
@@ -383,7 +383,7 @@ static NodePtr makeEnumNode(const Entity &e,
     string symbolsName = "symbols";
     const Array &v = getArrayField(e, m, symbolsName);
     concepts::MultiAttribute<string> symbols;
-    GenericDatum defaultValue;
+    std::optional<GenericDatum> defaultValue;
     for (const auto &it : v) {
         if (it.type() != json::EntityType::String) {
             throw Exception("Enum symbol not a string: {}", it.toString());

--- a/lang/c++/impl/NodeImpl.cc
+++ b/lang/c++/impl/NodeImpl.cc
@@ -329,13 +329,10 @@ void NodeRecord::printJson(std::ostream &os, size_t depth) const {
 
         // Serialize "default" field:
         if (!fieldsDefaultValues_.empty()) {
-            if (!fieldsDefaultValues_[i].isUnion() && fieldsDefaultValues_[i].type() == AVRO_NULL) {
-                // No "default" field.
-            } else {
+            if (fieldsDefaultValues_[i]) {
                 os << ",\n"
                    << indent(depth) << "\"default\": ";
-                leafAttributes_.get(i)->printDefaultToJson(fieldsDefaultValues_[i], os,
-                                                           depth);
+                leafAttributes_.get(i)->printDefaultToJson(*fieldsDefaultValues_[i], os, depth);
             }
         }
 
@@ -480,21 +477,21 @@ void NodeRecord::printDefaultToJson(const GenericDatum &g, std::ostream &os,
 }
 
 NodeRecord::NodeRecord(const HasName &name, const MultiLeaves &fields,
-                       const LeafNames &fieldsNames, std::vector<GenericDatum> dv)
+                       const LeafNames &fieldsNames, std::vector<std::optional<GenericDatum>> dv)
     : NodeRecord(name, HasDoc(), fields, fieldsNames, {}, std::move(dv), MultiAttributes()) {}
 
 NodeRecord::NodeRecord(const HasName &name, const HasDoc &doc, const MultiLeaves &fields,
-                       const LeafNames &fieldsNames, std::vector<GenericDatum> dv)
+                       const LeafNames &fieldsNames, std::vector<std::optional<GenericDatum>> dv)
     : NodeRecord(name, doc, fields, fieldsNames, {}, std::move(dv), MultiAttributes()) {}
 
 NodeRecord::NodeRecord(const HasName &name, const MultiLeaves &fields,
                        const LeafNames &fieldsNames, std::vector<std::vector<std::string>> fieldsAliases,
-                       std::vector<GenericDatum> dv, const MultiAttributes &customAttributes)
+                       std::vector<std::optional<GenericDatum>> dv, const MultiAttributes &customAttributes)
     : NodeRecord(name, HasDoc(), fields, fieldsNames, std::move(fieldsAliases), std::move(dv), customAttributes) {}
 
 NodeRecord::NodeRecord(const HasName &name, const HasDoc &doc, const MultiLeaves &fields,
                        const LeafNames &fieldsNames, std::vector<std::vector<std::string>> fieldsAliases,
-                       std::vector<GenericDatum> dv, const MultiAttributes &customAttributes)
+                       std::vector<std::optional<GenericDatum>> dv, const MultiAttributes &customAttributes)
     : NodeImplRecord(AVRO_RECORD, name, doc, fields, fieldsNames, customAttributes, NoSize()),
       fieldsAliases_(std::move(fieldsAliases)),
       fieldsDefaultValues_(std::move(dv)) {
@@ -560,10 +557,10 @@ void NodeEnum::printJson(std::ostream &os, size_t depth) const {
     os << '\n';
     os << indent(--depth) << "]";
 
-    if (defaultValue.type() != AVRO_NULL) {
+    if (defaultValue) {
         os << ",\n"
            << indent(depth) << "\"default\": ";
-        NodePrimitive{defaultValue.type()}.printDefaultToJson(defaultValue, os, depth);
+        NodePrimitive{defaultValue->type()}.printDefaultToJson(*defaultValue, os, depth);
     }
 
     os << "\n";

--- a/lang/c++/impl/Schema.cc
+++ b/lang/c++/impl/Schema.cc
@@ -17,6 +17,7 @@
  */
 
 #include <utility>
+#include <optional>
 
 #include "CustomAttributes.hh"
 #include "Schema.hh"
@@ -33,12 +34,10 @@ void RecordSchema::addField(const std::string &name, const Schema &fieldSchema) 
 }
 
 void RecordSchema::addField(const std::string &name, const Schema &fieldSchema, const CustomAttributes &customFields) {
-    // NOTE: GenericDatum() is the value used when compiling a schema if there
-    // is no default.
-    addField(name, fieldSchema, customFields, GenericDatum());
+    addField(name, fieldSchema, customFields, std::nullopt);
 }
 
-void RecordSchema::addField(const std::string &name, const Schema &fieldSchema, const CustomAttributes &customFields, const GenericDatum &fieldDefault) {
+void RecordSchema::addField(const std::string &name, const Schema &fieldSchema, const CustomAttributes &customFields, const std::optional<GenericDatum> &fieldDefault) {
     // add the name first. it will throw if the name is a duplicate, preventing
     // the leaf from being added
     node_->addName(name);

--- a/lang/c++/include/avro/Node.hh
+++ b/lang/c++/include/avro/Node.hh
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <memory>
 #include <utility>
+#include <optional>
 
 #include "CustomAttributes.hh"
 #include "Exception.hh"
@@ -144,7 +145,7 @@ public:
     }
     virtual size_t leaves() const = 0;
     virtual const NodePtr &leafAt(size_t index) const = 0;
-    virtual const GenericDatum &defaultValueAt(size_t index) const {
+    virtual const std::optional<GenericDatum> &defaultValueAt(size_t index) const {
         throw Exception("No default value at: {}", index);
     }
 
@@ -167,7 +168,7 @@ public:
         checkLock();
         doAddCustomAttribute(customAttributes);
     }
-    void addDefaultForField(const GenericDatum &fieldDefault) {
+    void addDefaultForField(const std::optional<GenericDatum> &fieldDefault) {
         checkLock();
         doAddDefault(fieldDefault);
     }
@@ -212,7 +213,7 @@ protected:
     virtual void doAddName(const std::string &name) = 0;
     virtual void doSetFixedSize(size_t size) = 0;
     virtual void doAddCustomAttribute(const CustomAttributes &customAttributes) = 0;
-    virtual void doAddDefault(const GenericDatum &fieldDefault) = 0;
+    virtual void doAddDefault(const std::optional<GenericDatum> &fieldDefault) = 0;
 
 private:
     const Type type_;

--- a/lang/c++/include/avro/NodeImpl.hh
+++ b/lang/c++/include/avro/NodeImpl.hh
@@ -172,7 +172,7 @@ protected:
     void doAddCustomAttribute(const CustomAttributes &customAttributes) override {
         customAttributes_.add(customAttributes);
     }
-    void doAddDefault(const GenericDatum &) override {
+    void doAddDefault(const std::optional<GenericDatum> &) override {
         throw Exception("Default only permitted for records");
     }
     SchemaResolution furtherResolution(const Node &reader) const {
@@ -306,24 +306,24 @@ protected:
 
 class AVRO_DECL NodeRecord : public NodeImplRecord {
     std::vector<std::vector<std::string>> fieldsAliases_;
-    std::vector<GenericDatum> fieldsDefaultValues_;
+    std::vector<std::optional<GenericDatum>> fieldsDefaultValues_;
 
 public:
     NodeRecord() : NodeImplRecord(AVRO_RECORD) {}
 
     NodeRecord(const HasName &name, const MultiLeaves &fields,
-               const LeafNames &fieldsNames, std::vector<GenericDatum> dv);
+               const LeafNames &fieldsNames, std::vector<std::optional<GenericDatum>> dv);
 
     NodeRecord(const HasName &name, const HasDoc &doc, const MultiLeaves &fields,
-               const LeafNames &fieldsNames, std::vector<GenericDatum> dv);
+               const LeafNames &fieldsNames, std::vector<std::optional<GenericDatum>> dv);
 
     NodeRecord(const HasName &name, const MultiLeaves &fields,
                const LeafNames &fieldsNames, std::vector<std::vector<std::string>> fieldsAliases,
-               std::vector<GenericDatum> dv, const MultiAttributes &customAttributes);
+               std::vector<std::optional<GenericDatum>> dv, const MultiAttributes &customAttributes);
 
     NodeRecord(const HasName &name, const HasDoc &doc, const MultiLeaves &fields,
                const LeafNames &fieldsNames, std::vector<std::vector<std::string>> fieldsAliases,
-               std::vector<GenericDatum> dv, const MultiAttributes &customAttributes);
+               std::vector<std::optional<GenericDatum>> dv, const MultiAttributes &customAttributes);
 
     void swap(NodeRecord &r) {
         NodeImplRecord::swap(r);
@@ -339,10 +339,10 @@ public:
         return ((nameAttribute_.size() == 1) && (leafAttributes_.size() == leafNameAttributes_.size()) && (customAttributes_.size() == 0 || customAttributes_.size() == leafAttributes_.size()));
     }
 
-    const GenericDatum &defaultValueAt(size_t index) const override {
+    const std::optional<GenericDatum> &defaultValueAt(size_t index) const override {
         return fieldsDefaultValues_[index];
     }
-    void doAddDefault(const GenericDatum &fieldDefault) override {
+    void doAddDefault(const std::optional<GenericDatum> &fieldDefault) override {
         fieldsDefaultValues_.push_back(fieldDefault);
     }
 
@@ -351,12 +351,12 @@ public:
 };
 
 class AVRO_DECL NodeEnum : public NodeImplEnum {
-    GenericDatum defaultValue;
+    std::optional<GenericDatum> defaultValue;
 
 public:
     NodeEnum() : NodeImplEnum(AVRO_ENUM) {}
 
-    NodeEnum(const HasName &name, const LeafNames &symbols, GenericDatum dv) : NodeImplEnum(AVRO_ENUM, name, NoLeaves(), symbols, NoAttributes(), NoSize()), defaultValue(std::move(dv)) {
+    NodeEnum(const HasName &name, const LeafNames &symbols, std::optional<GenericDatum> dv) : NodeImplEnum(AVRO_ENUM, name, NoLeaves(), symbols, NoAttributes(), NoSize()), defaultValue(std::move(dv)) {
         for (size_t i = 0; i < leafNameAttributes_.size(); ++i) {
             if (!nameIndex_.add(leafNameAttributes_.get(i), i)) {
                 throw Exception("Cannot add duplicate enum: {}", leafNameAttributes_.get(i));
@@ -379,7 +379,7 @@ public:
             (nameAttribute_.size() == 1) && (leafNameAttributes_.size() > 0));
     }
 
-    const GenericDatum &defaultValueAt(size_t index) const override {
+    const std::optional<GenericDatum> &defaultValueAt(size_t index) const override {
         if (index != 0) {
             throw Exception("Enum has only 1 default");
         }

--- a/lang/c++/include/avro/Schema.hh
+++ b/lang/c++/include/avro/Schema.hh
@@ -107,7 +107,7 @@ public:
     // Add a field with a field default
     void addField(const std::string &name, const Schema &fieldSchema,
                   const CustomAttributes &customAttributes,
-                  const GenericDatum &fieldDefault);
+                  const std::optional<GenericDatum> &fieldDefault);
 
     std::string getDoc() const;
     void setDoc(const std::string &);

--- a/lang/c++/test/SchemaTests.cc
+++ b/lang/c++/test/SchemaTests.cc
@@ -101,6 +101,8 @@ const char *basicSchemas[] = {
     R"({ "name":"test", "type": "record", "fields": [ {"name": "double","type": "double","default" : 2 }]})",
     // default double - double
     R"({ "name":"test", "type": "record", "fields": [ {"name": "double","type": "double","default" : 1.2 }]})",
+    // default same type as first of union
+    R"({ "name":"test", "type": "record", "fields": [ {"name": "opt_string","type": ["null", "string"],"default": null }]})",
 
     // namespace with '$' in it.
     "{\"type\":\"record\",\"name\":\"Test\",\"namespace\":\"a.b$\",\"fields\":"
@@ -162,7 +164,9 @@ const char *basicSchemaErrors[] = {
     // default double - null
     R"({ "name":"test", "type": "record", "fields": [ {"name": "double","type": "double","default" : null }]})",
     // default double - string
-    R"({ "name":"test", "type": "record", "fields": [ {"name": "double","type": "double","default" : "string" }]})"
+    R"({ "name":"test", "type": "record", "fields": [ {"name": "double","type": "double","default" : "string" }]})",
+    // default not same type as first of union
+    R"({ "name":"test", "type": "record", "fields": [ {"name": "opt_string","type": ["string", "null"],"default": null }]})",
 
 };
 

--- a/lang/c++/test/unittest.cc
+++ b/lang/c++/test/unittest.cc
@@ -436,7 +436,7 @@ struct TestSchema {
         concepts::MultiAttribute<std::string> fieldNames;
         std::vector<std::vector<std::string>> fieldAliases;
         concepts::MultiAttribute<NodePtr> fieldValues;
-        std::vector<GenericDatum> defaultValues;
+        std::vector<std::optional<GenericDatum>> defaultValues;
         concepts::MultiAttribute<CustomAttributes> customAttributes;
 
         CustomAttributes cf;
@@ -474,7 +474,7 @@ struct TestSchema {
         HasName nameConcept(recordName);
         concepts::MultiAttribute<std::string> fieldNames;
         concepts::MultiAttribute<NodePtr> fieldValues;
-        std::vector<GenericDatum> defaultValues;
+        std::vector<std::optional<GenericDatum>> defaultValues;
 
         fieldNames.add("f1");
         fieldValues.add(NodePtr(new NodePrimitive(Type::AVRO_LONG)));
@@ -559,6 +559,11 @@ struct TestSchema {
       "name": "f4_union_null_default",
       "type": ["null", "string"],
       "default": null
+    },
+    {
+      "name": "f5_null_default",
+      "type": "null",
+      "default": null
     }
   ]
 })";
@@ -566,15 +571,18 @@ struct TestSchema {
         const auto& nodePtr = *schema.root();
 
         BOOST_CHECK_EQUAL(nodePtr.type(), AVRO_RECORD);
-        BOOST_CHECK_EQUAL(nodePtr.defaultValueAt(0).type(), AVRO_NULL);
-        BOOST_CHECK_EQUAL(nodePtr.defaultValueAt(1).type(), AVRO_NULL);
-        BOOST_CHECK_EQUAL(nodePtr.defaultValueAt(2).type(), AVRO_NULL);
+        BOOST_CHECK_EQUAL(nodePtr.defaultValueAt(0).has_value(), false);
+        BOOST_CHECK_EQUAL(nodePtr.defaultValueAt(1).has_value(), false);
+        BOOST_CHECK_EQUAL(nodePtr.defaultValueAt(2).has_value(), false);
 
-        BOOST_CHECK_EQUAL(nodePtr.defaultValueAt(3).type(), AVRO_STRING);
-        BOOST_CHECK_EQUAL(nodePtr.defaultValueAt(3).isUnion(), true);
+        BOOST_CHECK_EQUAL(nodePtr.defaultValueAt(3)->type(), AVRO_STRING);
+        BOOST_CHECK_EQUAL(nodePtr.defaultValueAt(3)->isUnion(), true);
 
-        BOOST_CHECK_EQUAL(nodePtr.defaultValueAt(4).type(), AVRO_NULL);
-        BOOST_CHECK_EQUAL(nodePtr.defaultValueAt(4).isUnion(), true);
+        BOOST_CHECK_EQUAL(nodePtr.defaultValueAt(4)->type(), AVRO_NULL);
+        BOOST_CHECK_EQUAL(nodePtr.defaultValueAt(4)->isUnion(), true);
+
+        BOOST_CHECK_EQUAL(nodePtr.defaultValueAt(5)->type(), AVRO_NULL);
+        BOOST_CHECK_EQUAL(nodePtr.defaultValueAt(5)->isUnion(), false);
 
         testNode(nodePtr, jsonWithDefaults);
     }


### PR DESCRIPTION
Before this change, there was no way to differentiate between an explicit null default value and an omitted default value for a record field.

This lead to bugs in redpanda's schema registry when it couldn't perform appropriate compatibility checks on default values.

https://redpandadata.atlassian.net/browse/CORE-1796